### PR TITLE
Fix compatibility with pydantic >= 1.10.3

### DIFF
--- a/sslyze/plugins/compression_plugin.py
+++ b/sslyze/plugins/compression_plugin.py
@@ -32,7 +32,7 @@ class CompressionScanResult(ScanCommandResult):
 
 
 # Identical fields in the JSON output
-CompressionScanResultAsJson = pydantic.dataclasses.dataclass(CompressionScanResult, frozen=True)
+CompressionScanResultAsJson = pydantic.dataclasses.dataclass(CompressionScanResult)
 
 
 class CompressionScanAttemptAsJson(ScanCommandAttemptAsJson):

--- a/sslyze/plugins/early_data_plugin.py
+++ b/sslyze/plugins/early_data_plugin.py
@@ -33,7 +33,7 @@ class EarlyDataScanResult(ScanCommandResult):
 
 
 # Identical fields in the JSON output
-EarlyDataScanResultAsJson = pydantic.dataclasses.dataclass(EarlyDataScanResult, frozen=True)
+EarlyDataScanResultAsJson = pydantic.dataclasses.dataclass(EarlyDataScanResult)
 
 
 class EarlyDataScanAttemptAsJson(ScanCommandAttemptAsJson):

--- a/sslyze/plugins/fallback_scsv_plugin.py
+++ b/sslyze/plugins/fallback_scsv_plugin.py
@@ -31,7 +31,7 @@ class FallbackScsvScanResult(ScanCommandResult):
 
 
 # Identical fields in the JSON output
-FallbackScsvScanResultAsJson = pydantic.dataclasses.dataclass(FallbackScsvScanResult, frozen=True)
+FallbackScsvScanResultAsJson = pydantic.dataclasses.dataclass(FallbackScsvScanResult)
 
 
 class FallbackScsvScanAttemptAsJson(ScanCommandAttemptAsJson):

--- a/sslyze/plugins/heartbleed_plugin.py
+++ b/sslyze/plugins/heartbleed_plugin.py
@@ -38,7 +38,7 @@ class HeartbleedScanResult(ScanCommandResult):
 
 
 # Identical fields in the JSON output
-HeartbleedScanResultAsJson = pydantic.dataclasses.dataclass(HeartbleedScanResult, frozen=True)
+HeartbleedScanResultAsJson = pydantic.dataclasses.dataclass(HeartbleedScanResult)
 
 
 class HeartbleedScanAttemptAsJson(ScanCommandAttemptAsJson):

--- a/sslyze/plugins/openssl_ccs_injection_plugin.py
+++ b/sslyze/plugins/openssl_ccs_injection_plugin.py
@@ -39,7 +39,7 @@ class OpenSslCcsInjectionScanResult(ScanCommandResult):
 
 
 # Identical fields in the JSON output
-OpenSslCcsInjectionScanResultAsJson = pydantic.dataclasses.dataclass(OpenSslCcsInjectionScanResult, frozen=True)
+OpenSslCcsInjectionScanResultAsJson = pydantic.dataclasses.dataclass(OpenSslCcsInjectionScanResult)
 
 
 class OpenSslCcsInjectionScanAttemptAsJson(ScanCommandAttemptAsJson):

--- a/sslyze/plugins/robot/implementation.py
+++ b/sslyze/plugins/robot/implementation.py
@@ -36,7 +36,7 @@ class RobotScanResult(ScanCommandResult):
 
 
 # Identical fields in the JSON output
-RobotScanResultAsJson = pydantic.dataclasses.dataclass(RobotScanResult, frozen=True)
+RobotScanResultAsJson = pydantic.dataclasses.dataclass(RobotScanResult)
 
 
 class RobotScanAttemptAsJson(ScanCommandAttemptAsJson):

--- a/sslyze/plugins/session_renegotiation_plugin.py
+++ b/sslyze/plugins/session_renegotiation_plugin.py
@@ -35,7 +35,7 @@ class SessionRenegotiationScanResult(ScanCommandResult):
 
 
 # Identical fields in the JSON output
-SessionRenegotiationScanResultAsJson = pydantic.dataclasses.dataclass(SessionRenegotiationScanResult, frozen=True)
+SessionRenegotiationScanResultAsJson = pydantic.dataclasses.dataclass(SessionRenegotiationScanResult)
 
 
 class SessionRenegotiationScanAttemptAsJson(ScanCommandAttemptAsJson):


### PR DESCRIPTION
This fixes https://github.com/nabla-c0d3/sslyze/issues/586 with the suggestion from https://github.com/pydantic/pydantic/issues/4907#issuecomment-1370980452 so that SSLyze continues working with pydantic 1.10.3, 1.10.4 and hopefully later versions too :)

Signed-off-by: Mark Zeman <zeman@puzzle.ch>